### PR TITLE
Fix single second duration string

### DIFF
--- a/src/utils/minutesToDurationString.test.ts
+++ b/src/utils/minutesToDurationString.test.ts
@@ -1,7 +1,7 @@
 import { minutesToDurationString } from "./minutesToDurationString";
 
 const tests = [
-        [0.01667, "1 second"],
+	[0.01667, "1 second"],
 	[0.1667, "10 seconds"],
 	[0.25, "15 seconds"],
 	[0.5, "30 seconds"],

--- a/src/utils/minutesToDurationString.test.ts
+++ b/src/utils/minutesToDurationString.test.ts
@@ -1,7 +1,7 @@
 import { minutesToDurationString } from "./minutesToDurationString";
 
 const tests = [
-	[0.01667, "1 seconds"],
+        [0.01667, "1 second"],
 	[0.1667, "10 seconds"],
 	[0.25, "15 seconds"],
 	[0.5, "30 seconds"],

--- a/src/utils/minutesToDurationString.ts
+++ b/src/utils/minutesToDurationString.ts
@@ -1,8 +1,8 @@
 export function minutesToDurationString(minutes: number): string {
-        if (minutes < 1 && minutes !== 0) {
-                const seconds = Math.floor(minutes * 60);
-                return `${seconds} second${seconds === 1 ? "" : "s"}`;
-        }
+	if (minutes < 1 && minutes !== 0) {
+		const seconds = Math.floor(minutes * 60);
+		return `${seconds} second${seconds === 1 ? "" : "s"}`;
+	}
 
 	const hours = Math.floor(minutes / 60);
 	const remainingMinutes = minutes % 60;

--- a/src/utils/minutesToDurationString.ts
+++ b/src/utils/minutesToDurationString.ts
@@ -1,7 +1,8 @@
 export function minutesToDurationString(minutes: number): string {
-	if (minutes < 1 && minutes !== 0) {
-		return `${Math.floor(minutes * 60)} seconds`;
-	}
+        if (minutes < 1 && minutes !== 0) {
+                const seconds = Math.floor(minutes * 60);
+                return `${seconds} second${seconds === 1 ? "" : "s"}`;
+        }
 
 	const hours = Math.floor(minutes / 60);
 	const remainingMinutes = minutes % 60;


### PR DESCRIPTION
## Summary
- handle singular `second` for minute durations
- adjust test expectation accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404d3eb0a883309fbf130b80ea13dc