### PR TITLE
Add invalid duration string tests

### DIFF
--- a/src/utils/parseDurationString.test.ts
+++ b/src/utils/parseDurationString.test.ts
@@ -1,6 +1,6 @@
 import { parseDurationString } from "./parseDurationString";
 
-const tests = [
+const tests: Array<[string, number | undefined]> = [
 	["1 minute", 1],
 	["5 minutes", 5],
 	["15 minutes", 15],
@@ -10,9 +10,11 @@ const tests = [
 	["1 hour", 60],
 	["1 hour and 1 minute", 61],
 	["1 hour and 5 minutes", 65],
-	["5 hours", 300],
-	["5 hours and 1 minute", 301],
-	["5 hours and 30 minutes", 330],
+        ["5 hours", 300],
+        ["5 hours and 1 minute", 301],
+        ["5 hours and 30 minutes", 330],
+        ["ten minutes", undefined],
+        ["1 hr", undefined],
 ];
 
 test.each(tests)("parseDurationString(%p) === %p", (input, expected) => {

--- a/src/utils/parseDurationString.test.ts
+++ b/src/utils/parseDurationString.test.ts
@@ -10,11 +10,11 @@ const tests: Array<[string, number | undefined]> = [
 	["1 hour", 60],
 	["1 hour and 1 minute", 61],
 	["1 hour and 5 minutes", 65],
-        ["5 hours", 300],
-        ["5 hours and 1 minute", 301],
-        ["5 hours and 30 minutes", 330],
-        ["ten minutes", undefined],
-        ["1 hr", undefined],
+	["5 hours", 300],
+	["5 hours and 1 minute", 301],
+	["5 hours and 30 minutes", 330],
+	["ten minutes", undefined],
+	["1 hr", undefined],
 ];
 
 test.each(tests)("parseDurationString(%p) === %p", (input, expected) => {


### PR DESCRIPTION
## Summary
- add invalid cases in `parseDurationString` tests
- specify tuple type to allow undefined results

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68404d49aff48330bc0365eb7342bce3