### PR TITLE
Add retry logic with Retry-After support for FAA API fetch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { NaturalEarthDataManager } from "./NaturalEarthDataManager";
 import { ImageGenerator } from "./ImageGenerator";
 import express from "express";
 import { minutesToDurationString } from "./utils/minutesToDurationString";
+import { fetchWithRetry } from "./utils/fetchWithRetry";
 import { S3 } from "@aws-sdk/client-s3";
 
 const packageJSON = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"));
@@ -120,19 +121,18 @@ async function run (firstRun: boolean) {
 	}
 
 	let xmlResult: string;
-	try {
-		xmlResult = await (await fetch(XML_ENDPOINT, {
-			"method": "GET",
-			"headers": {
-				"User-Agent": USER_AGENT
-			}
-		})).text();
-		console.log("Got XML", xmlResult);
-	} catch (e) {
-		console.error("Failed to get XML");
-		console.error(e);
+	const xmlResponse = await fetchWithRetry(XML_ENDPOINT, {
+		"method": "GET",
+		"headers": {
+			"User-Agent": USER_AGENT
+		}
+	});
+	if (!xmlResponse) {
+		console.error("Failed to get XML after all retry attempts. Skipping this run.");
 		return;
 	}
+	xmlResult = await xmlResponse.text();
+	console.log("Got XML", xmlResult);
 
 	console.time("Run Parse");
 	const previousPath = path.join(__dirname, "..", "cache", "previous.xml");

--- a/src/utils/fetchWithRetry.test.ts
+++ b/src/utils/fetchWithRetry.test.ts
@@ -1,4 +1,4 @@
-import { fetchWithRetry } from "./fetchWithRetry";
+import { fetchWithRetry, parseRetryAfterMs } from "./fetchWithRetry";
 
 const mockFetch = jest.fn();
 (global as any).fetch = mockFetch;
@@ -10,8 +10,51 @@ afterEach(() => {
 	jest.clearAllMocks();
 });
 
+// --- parseRetryAfterMs ---
+
+describe("parseRetryAfterMs", () => {
+	test("returns null for null input", () => {
+		expect(parseRetryAfterMs(null)).toBeNull();
+	});
+
+	test("parses integer seconds", () => {
+		expect(parseRetryAfterMs("120")).toBe(120_000);
+	});
+
+	test("parses zero seconds", () => {
+		expect(parseRetryAfterMs("0")).toBe(0);
+	});
+
+	test("parses HTTP-date in the future", () => {
+		const futureDate = new Date(Date.now() + 5000);
+		const result = parseRetryAfterMs(futureDate.toUTCString());
+		expect(result).toBeGreaterThan(0);
+		expect(result).toBeLessThanOrEqual(5000);
+	});
+
+	test("returns 0 for HTTP-date in the past", () => {
+		const pastDate = new Date(Date.now() - 5000);
+		expect(parseRetryAfterMs(pastDate.toUTCString())).toBe(0);
+	});
+
+	test("returns null for unparseable string", () => {
+		expect(parseRetryAfterMs("not-a-date-or-number")).toBeNull();
+	});
+});
+
+// --- fetchWithRetry ---
+
+function makeMockResponse(status: number, headers: Record<string, string> = {}): Response {
+	return {
+		status,
+		headers: {
+			get: (key: string) => headers[key.toLowerCase()] ?? null,
+		},
+	} as unknown as Response;
+}
+
 test("returns response immediately on first success", async () => {
-	const mockResponse = { status: 200 } as Response;
+	const mockResponse = makeMockResponse(200);
 	mockFetch.mockResolvedValueOnce(mockResponse);
 
 	const promise = fetchWithRetry("https://example.com", {}, 3);
@@ -22,8 +65,20 @@ test("returns response immediately on first success", async () => {
 	expect(mockFetch).toHaveBeenCalledTimes(1);
 });
 
-test("retries on failure and succeeds on second attempt", async () => {
-	const mockResponse = { status: 200 } as Response;
+test("returns non-retriable 4xx response immediately without retrying", async () => {
+	const mockResponse = makeMockResponse(404);
+	mockFetch.mockResolvedValueOnce(mockResponse);
+
+	const promise = fetchWithRetry("https://example.com", {}, 3);
+	await jest.runAllTimersAsync();
+	const result = await promise;
+
+	expect(result).toBe(mockResponse);
+	expect(mockFetch).toHaveBeenCalledTimes(1);
+});
+
+test("retries on network error and succeeds on second attempt", async () => {
+	const mockResponse = makeMockResponse(200);
 	mockFetch.mockRejectedValueOnce(new Error("Network error")).mockResolvedValueOnce(mockResponse);
 
 	const promise = fetchWithRetry("https://example.com", {}, 3);
@@ -34,8 +89,76 @@ test("retries on failure and succeeds on second attempt", async () => {
 	expect(mockFetch).toHaveBeenCalledTimes(2);
 });
 
+test("retries on 429 and succeeds on second attempt", async () => {
+	const rateLimited = makeMockResponse(429);
+	const ok = makeMockResponse(200);
+	mockFetch.mockResolvedValueOnce(rateLimited).mockResolvedValueOnce(ok);
+
+	const promise = fetchWithRetry("https://example.com", {}, 3);
+	await jest.runAllTimersAsync();
+	const result = await promise;
+
+	expect(result).toBe(ok);
+	expect(mockFetch).toHaveBeenCalledTimes(2);
+});
+
+test("retries on 503 and succeeds on second attempt", async () => {
+	const serverError = makeMockResponse(503);
+	const ok = makeMockResponse(200);
+	mockFetch.mockResolvedValueOnce(serverError).mockResolvedValueOnce(ok);
+
+	const promise = fetchWithRetry("https://example.com", {}, 3);
+	await jest.runAllTimersAsync();
+	const result = await promise;
+
+	expect(result).toBe(ok);
+	expect(mockFetch).toHaveBeenCalledTimes(2);
+});
+
+test("respects Retry-After seconds header on 429", async () => {
+	const rateLimited = makeMockResponse(429, { "retry-after": "30" });
+	const ok = makeMockResponse(200);
+	mockFetch.mockResolvedValueOnce(rateLimited).mockResolvedValueOnce(ok);
+
+	const setTimeoutSpy = jest.spyOn(global, "setTimeout");
+
+	const promise = fetchWithRetry("https://example.com", {}, 3);
+	await jest.runAllTimersAsync();
+	await promise;
+
+	const delays = setTimeoutSpy.mock.calls.map((call) => call[1]);
+	expect(delays).toContain(30_000);
+});
+
+test("respects Retry-After HTTP-date header on 429", async () => {
+	const futureDate = new Date(Date.now() + 10_000).toUTCString();
+	const rateLimited = makeMockResponse(429, { "retry-after": futureDate });
+	const ok = makeMockResponse(200);
+	mockFetch.mockResolvedValueOnce(rateLimited).mockResolvedValueOnce(ok);
+
+	const setTimeoutSpy = jest.spyOn(global, "setTimeout");
+
+	const promise = fetchWithRetry("https://example.com", {}, 3);
+	await jest.runAllTimersAsync();
+	await promise;
+
+	const delays = setTimeoutSpy.mock.calls.map((call) => call[1]);
+	expect(delays.some((d) => (d as number) > 0 && (d as number) <= 10_000)).toBe(true);
+});
+
 test("returns null after all attempts fail", async () => {
 	mockFetch.mockRejectedValue(new Error("Network error"));
+
+	const promise = fetchWithRetry("https://example.com", {}, 3);
+	await jest.runAllTimersAsync();
+	const result = await promise;
+
+	expect(result).toBeNull();
+	expect(mockFetch).toHaveBeenCalledTimes(3);
+});
+
+test("returns null after all attempts return retriable status", async () => {
+	mockFetch.mockResolvedValue(makeMockResponse(429));
 
 	const promise = fetchWithRetry("https://example.com", {}, 3);
 	await jest.runAllTimersAsync();
@@ -56,7 +179,7 @@ test("does not retry more than maxAttempts times", async () => {
 });
 
 test("passes options to fetch", async () => {
-	const mockResponse = { status: 200 } as Response;
+	const mockResponse = makeMockResponse(200);
 	mockFetch.mockResolvedValueOnce(mockResponse);
 
 	const options = { method: "GET", headers: { "User-Agent": "test" } };

--- a/src/utils/fetchWithRetry.test.ts
+++ b/src/utils/fetchWithRetry.test.ts
@@ -1,0 +1,68 @@
+import { fetchWithRetry } from "./fetchWithRetry";
+
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+// Speed up tests by using fake timers
+jest.useFakeTimers();
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+test("returns response immediately on first success", async () => {
+	const mockResponse = { status: 200 } as Response;
+	mockFetch.mockResolvedValueOnce(mockResponse);
+
+	const promise = fetchWithRetry("https://example.com", {}, 3);
+	await jest.runAllTimersAsync();
+	const result = await promise;
+
+	expect(result).toBe(mockResponse);
+	expect(mockFetch).toHaveBeenCalledTimes(1);
+});
+
+test("retries on failure and succeeds on second attempt", async () => {
+	const mockResponse = { status: 200 } as Response;
+	mockFetch.mockRejectedValueOnce(new Error("Network error")).mockResolvedValueOnce(mockResponse);
+
+	const promise = fetchWithRetry("https://example.com", {}, 3);
+	await jest.runAllTimersAsync();
+	const result = await promise;
+
+	expect(result).toBe(mockResponse);
+	expect(mockFetch).toHaveBeenCalledTimes(2);
+});
+
+test("returns null after all attempts fail", async () => {
+	mockFetch.mockRejectedValue(new Error("Network error"));
+
+	const promise = fetchWithRetry("https://example.com", {}, 3);
+	await jest.runAllTimersAsync();
+	const result = await promise;
+
+	expect(result).toBeNull();
+	expect(mockFetch).toHaveBeenCalledTimes(3);
+});
+
+test("does not retry more than maxAttempts times", async () => {
+	mockFetch.mockRejectedValue(new Error("Network error"));
+
+	const promise = fetchWithRetry("https://example.com", {}, 2);
+	await jest.runAllTimersAsync();
+	await promise;
+
+	expect(mockFetch).toHaveBeenCalledTimes(2);
+});
+
+test("passes options to fetch", async () => {
+	const mockResponse = { status: 200 } as Response;
+	mockFetch.mockResolvedValueOnce(mockResponse);
+
+	const options = { method: "GET", headers: { "User-Agent": "test" } };
+	const promise = fetchWithRetry("https://example.com", options, 3);
+	await jest.runAllTimersAsync();
+	await promise;
+
+	expect(mockFetch).toHaveBeenCalledWith("https://example.com", options);
+});

--- a/src/utils/fetchWithRetry.ts
+++ b/src/utils/fetchWithRetry.ts
@@ -1,0 +1,28 @@
+const DEFAULT_MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 2000;
+
+/**
+ * Fetches a URL, retrying on failure with exponential backoff.
+ * Returns the Response on success, or null if all attempts fail.
+ */
+export async function fetchWithRetry(url: string, options: RequestInit = {}, maxAttempts: number = DEFAULT_MAX_ATTEMPTS): Promise<Response | null> {
+	let lastError: unknown;
+
+	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+		try {
+			const response = await fetch(url, options);
+			return response;
+		} catch (e) {
+			lastError = e;
+			if (attempt < maxAttempts) {
+				const delayMs = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+				console.warn(`Fetch attempt ${attempt}/${maxAttempts} failed for ${url}. Retrying in ${delayMs}ms...`);
+				await new Promise((resolve) => setTimeout(resolve, delayMs));
+			}
+		}
+	}
+
+	console.error(`All ${maxAttempts} fetch attempts failed for ${url}.`);
+	console.error(lastError);
+	return null;
+}

--- a/src/utils/fetchWithRetry.ts
+++ b/src/utils/fetchWithRetry.ts
@@ -1,9 +1,38 @@
 const DEFAULT_MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 2000;
 
+const RETRIABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+
 /**
- * Fetches a URL, retrying on failure with exponential backoff.
- * Returns the Response on success, or null if all attempts fail.
+ * Parses a Retry-After header value into a delay in milliseconds.
+ * Supports both integer seconds ("120") and HTTP-date formats ("Fri, 01 Jan 2027 00:00:00 GMT").
+ * Returns null if the header is absent or unparseable.
+ */
+export function parseRetryAfterMs(retryAfter: string | null): number | null {
+	if (!retryAfter) {
+		return null;
+	}
+
+	const seconds = Number(retryAfter);
+	if (!isNaN(seconds) && seconds >= 0) {
+		return seconds * 1000;
+	}
+
+	const date = new Date(retryAfter);
+	if (!isNaN(date.getTime())) {
+		const delayMs = date.getTime() - Date.now();
+		return delayMs > 0 ? delayMs : 0;
+	}
+
+	return null;
+}
+
+/**
+ * Fetches a URL, retrying on network errors and retriable HTTP status codes
+ * (429, 500, 502, 503, 504) with exponential backoff.
+ * Respects the Retry-After header on 429 responses.
+ * Non-retriable responses (2xx, non-429 4xx) are returned immediately.
+ * Returns null if all attempts fail.
  */
 export async function fetchWithRetry(url: string, options: RequestInit = {}, maxAttempts: number = DEFAULT_MAX_ATTEMPTS): Promise<Response | null> {
 	let lastError: unknown;
@@ -11,7 +40,26 @@ export async function fetchWithRetry(url: string, options: RequestInit = {}, max
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		try {
 			const response = await fetch(url, options);
-			return response;
+
+			if (!RETRIABLE_STATUS_CODES.has(response.status)) {
+				return response;
+			}
+
+			lastError = new Error(`HTTP ${response.status}`);
+
+			if (attempt < maxAttempts) {
+				let delayMs = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+
+				const retryAfterMs = parseRetryAfterMs(response.headers.get("Retry-After"));
+				if (retryAfterMs !== null) {
+					delayMs = retryAfterMs;
+					console.warn(`Fetch attempt ${attempt}/${maxAttempts} got ${response.status} for ${url}. Respecting Retry-After: retrying in ${delayMs}ms...`);
+				} else {
+					console.warn(`Fetch attempt ${attempt}/${maxAttempts} got ${response.status} for ${url}. Retrying in ${delayMs}ms...`);
+				}
+
+				await new Promise((resolve) => setTimeout(resolve, delayMs));
+			}
 		} catch (e) {
 			lastError = e;
 			if (attempt < maxAttempts) {


### PR DESCRIPTION
## Why

A single transient network blip or rate-limit response from the FAA API would cause the entire polling cycle to be silently skipped. Over a 60-second refresh window this means a missed run with no recovery attempt, potentially causing delayed or missed delay announcements.

## What changed

A new `fetchWithRetry` utility wraps the native `fetch` call with up to 3 attempts and exponential backoff (2 s, 4 s). It handles two classes of failure:

- **Network errors** (thrown exceptions) — retried with exponential backoff as before.
- **Retriable HTTP status codes** (`429`, `500`, `502`, `503`, `504`) — also retried. Non-retriable responses (`2xx`, non-429 `4xx`) are returned immediately without consuming retry budget.

For `429 Too Many Requests`, the `Retry-After` header is parsed and used as the wait delay instead of backoff. Both formats are supported:
- Integer seconds: `Retry-After: 120`
- HTTP-date: `Retry-After: Fri, 01 Apr 2026 00:00:00 GMT`

Each failed attempt logs a `console.warn` with the attempt count and delay. If all attempts are exhausted, `fetchWithRetry` logs `console.error` with the final error and returns `null`, and the caller in `index.ts` exits the current run cleanly.

## Files

- `src/utils/fetchWithRetry.ts` — new utility (`fetchWithRetry` + exported `parseRetryAfterMs`)
- `src/utils/fetchWithRetry.test.ts` — 17 tests covering success, network errors, HTTP 429/503, `Retry-After` seconds, `Retry-After` HTTP-date, non-retriable 4xx passthrough, and exhausted attempts
- `src/index.ts` — replaced bare `fetch` + try/catch with `fetchWithRetry`