### PR TITLE
Fix missing date in closure extension reply when end time crosses a day boundary

### DIFF
--- a/src/types/Status.test.ts
+++ b/src/types/Status.test.ts
@@ -887,6 +887,56 @@ describe("Status.updatedPost()", () => {
 				}
 			},
 			"The ground delay at Test Airport A (#AAA) now has an average delay of 45 minutes and a maximum delay of 4 hours."
+		],
+		[
+			{
+				"Name": "Airport Closures",
+				"Airport_Closure_List": {
+					"Airport": {
+						"ARPT": "AAA",
+						"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+						"Start": "Dec 13 at 18:00 UTC.",
+						"Reopen": "Dec 13 at 18:00 UTC."
+					}
+				}
+			},
+			{
+				"Name": "Airport Closures",
+				"Airport_Closure_List": {
+					"Airport": {
+						"ARPT": "AAA",
+						"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+						"Start": "Dec 13 at 18:00 UTC.",
+						"Reopen": "Dec 21 at 18:00 UTC."
+					}
+				}
+			},
+			"The airport closure at Test Airport A (#AAA) has been extended by 192 hours to December 21 at 11:00 AM."
+		],
+		[
+			{
+				"Name": "Airport Closures",
+				"Airport_Closure_List": {
+					"Airport": {
+						"ARPT": "AAA",
+						"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+						"Start": "Dec 13 at 18:00 UTC.",
+						"Reopen": "Dec 21 at 18:00 UTC."
+					}
+				}
+			},
+			{
+				"Name": "Airport Closures",
+				"Airport_Closure_List": {
+					"Airport": {
+						"ARPT": "AAA",
+						"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+						"Start": "Dec 13 at 18:00 UTC.",
+						"Reopen": "Dec 13 at 18:00 UTC."
+					}
+				}
+			},
+			"The airport closure at Test Airport A (#AAA) has been reduced by 192 hours to December 13 at 11:00 AM."
 		]
 	];
 

--- a/src/types/Status.test.ts
+++ b/src/types/Status.test.ts
@@ -354,6 +354,12 @@ describe("Status.fromRAW().toEndedPost()", () => {
 });
 
 describe("Status.updatedPost()", () => {
+	// Used by the date-aware branch tests below. Computed once at load time so
+	// the Reopen dates (which Luxon parses into the current year) stay in sync.
+	const thisYear = new Date().getFullYear();
+	// Day name for April 9 in the current year, as seen in the America/Denver zone.
+	const apr9DayName = new Intl.DateTimeFormat("en-US", { "weekday": "long", "timeZone": "America/Denver" }).format(new Date(`${thisYear}-04-09T20:00:00Z`));
+
 	const tests = [
 		[
 			{
@@ -937,80 +943,99 @@ describe("Status.updatedPost()", () => {
 				}
 			},
 			"The airport closure at Test Airport A (#AAA) has been reduced by 192 hours to December 13 at 11:00 AM."
+		],
+		// isToday branch: new end is on the same local day as now → output is time-only
+		// Apr 08 19:00 UTC = 1:00 PM MDT (America/Denver, UTC-6 in April)
+		[
+			{
+				"Name": "Airport Closures",
+				"Airport_Closure_List": {
+					"Airport": {
+						"ARPT": "AAA",
+						"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+						"Start": "Apr 08 at 18:00 UTC.",
+						"Reopen": "Apr 08 at 18:00 UTC."
+					}
+				}
+			},
+			{
+				"Name": "Airport Closures",
+				"Airport_Closure_List": {
+					"Airport": {
+						"ARPT": "AAA",
+						"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+						"Start": "Apr 08 at 18:00 UTC.",
+						"Reopen": "Apr 08 at 19:00 UTC."
+					}
+				}
+			},
+			"The airport closure at Test Airport A (#AAA) has been extended by 1 hour to 1:00 PM.",
+			new Date(`${thisYear}-04-08T12:00:00Z`)
+		],
+		// isSameWeek branch: new end is the next day (same ISO week) → output is day-name + time.
+		// Apr 09 20:00 UTC = 2:00 PM MDT. Day name is computed dynamically to stay correct across years.
+		[
+			{
+				"Name": "Airport Closures",
+				"Airport_Closure_List": {
+					"Airport": {
+						"ARPT": "AAA",
+						"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+						"Start": "Apr 08 at 18:00 UTC.",
+						"Reopen": "Apr 08 at 18:00 UTC."
+					}
+				}
+			},
+			{
+				"Name": "Airport Closures",
+				"Airport_Closure_List": {
+					"Airport": {
+						"ARPT": "AAA",
+						"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+						"Start": "Apr 08 at 18:00 UTC.",
+						"Reopen": "Apr 09 at 20:00 UTC."
+					}
+				}
+			},
+			`The airport closure at Test Airport A (#AAA) has been extended by 26 hours to ${apr9DayName} at 2:00 PM.`,
+			new Date(`${thisYear}-04-08T12:00:00Z`)
+		],
+		// differentYear branch: now is in the previous year so the end date falls in a different year
+		// → output includes the full year. isSameYear is already covered by the Dec 21 tests above.
+		[
+			{
+				"Name": "Airport Closures",
+				"Airport_Closure_List": {
+					"Airport": {
+						"ARPT": "AAA",
+						"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+						"Start": "Dec 13 at 18:00 UTC.",
+						"Reopen": "Dec 13 at 18:00 UTC."
+					}
+				}
+			},
+			{
+				"Name": "Airport Closures",
+				"Airport_Closure_List": {
+					"Airport": {
+						"ARPT": "AAA",
+						"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+						"Start": "Dec 13 at 18:00 UTC.",
+						"Reopen": "Dec 21 at 18:00 UTC."
+					}
+				}
+			},
+			`The airport closure at Test Airport A (#AAA) has been extended by 192 hours to December 21, ${thisYear} at 11:00 AM.`,
+			new Date(`${thisYear - 1}-04-08T12:00:00Z`)
 		]
 	];
 
-	tests.forEach(([oldJSON, newJSON, expected]) => {
+	tests.forEach(([oldJSON, newJSON, expected, now]) => {
 		test(`Status.updatedPost() === ${expected}`, async () => {
 			const oldObj: any = Status.fromRaw(oldJSON as any, new OurAirportsDataManager("Test"), new NaturalEarthDataManager("Test"));
 			const newObj: any = Status.fromRaw(newJSON as any, new OurAirportsDataManager("Test"), new NaturalEarthDataManager("Test"));
 
-			expect(await Status.updatedPost(oldObj, newObj)).toStrictEqual(expected);
-		});
-	});
-
-	// Explicit tests for each date-aware branch in updatedPost().
-	// AAA is in America/Denver: MDT (UTC-6) in spring, MST (UTC-7) in winter.
-	// All tests pass an explicit `now` to avoid coupling to the real system clock.
-	describe("date-aware end time formatting", () => {
-		const dm = new OurAirportsDataManager("Test");
-		const ndm = new NaturalEarthDataManager("Test");
-		const closureRaw = (start: string, reopen: string) => ({
-			"Name": "Airport Closures",
-			"Airport_Closure_List": {
-				"Airport": {
-					"ARPT": "AAA",
-					"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
-					"Start": start,
-					"Reopen": reopen
-				}
-			}
-		});
-
-		test("isToday: shows time only (no date)", async () => {
-			// now = April 8, 2026 noon UTC → April 8 6:00 AM MDT (UTC-6)
-			// new Reopen = Apr 08 at 21:00 UTC → April 8 3:00 PM MDT → isToday
-			const now = new Date("2026-04-08T12:00:00Z");
-			const oldObj = Status.fromRaw(closureRaw("Apr 08 at 18:00 UTC.", "Apr 08 at 18:00 UTC."), dm, ndm) as Status;
-			const newObj = Status.fromRaw(closureRaw("Apr 08 at 18:00 UTC.", "Apr 08 at 21:00 UTC."), dm, ndm) as Status;
-			expect(await Status.updatedPost(oldObj, newObj, now)).toBe(
-				"The airport closure at Test Airport A (#AAA) has been extended by 3 hours to 3:00 PM."
-			);
-		});
-
-		test("isSameWeek: shows day name + time", async () => {
-			// now = April 8, 2026 (Wednesday) noon UTC
-			// new Reopen = Apr 10 at 18:00 UTC → April 10 (Friday) noon MDT → same ISO week, not today
-			const now = new Date("2026-04-08T12:00:00Z");
-			const oldObj = Status.fromRaw(closureRaw("Apr 08 at 18:00 UTC.", "Apr 08 at 18:00 UTC."), dm, ndm) as Status;
-			const newObj = Status.fromRaw(closureRaw("Apr 08 at 18:00 UTC.", "Apr 10 at 18:00 UTC."), dm, ndm) as Status;
-			expect(await Status.updatedPost(oldObj, newObj, now)).toBe(
-				"The airport closure at Test Airport A (#AAA) has been extended by 48 hours to Friday at noon."
-			);
-		});
-
-		test("isSameYear: shows month + day + time", async () => {
-			// now = April 8, 2026; new Reopen = Dec 21, 2026 → same year, different week
-			// Dec 21 at 18:00 UTC → Dec 21 11:00 AM MST (UTC-7)
-			const now = new Date("2026-04-08T12:00:00Z");
-			const oldObj = Status.fromRaw(closureRaw("Dec 13 at 18:00 UTC.", "Dec 13 at 18:00 UTC."), dm, ndm) as Status;
-			const newObj = Status.fromRaw(closureRaw("Dec 13 at 18:00 UTC.", "Dec 21 at 18:00 UTC."), dm, ndm) as Status;
-			expect(await Status.updatedPost(oldObj, newObj, now)).toBe(
-				"The airport closure at Test Airport A (#AAA) has been extended by 192 hours to December 21 at 11:00 AM."
-			);
-		});
-
-		test("different year: shows full date with year + time", async () => {
-			// now = Dec 31, 2026; new end = Jan 5, 2027 → different year
-			// Jan 5, 2027 18:00 UTC → Jan 5 11:00 AM MST (UTC-7)
-			const now = new Date("2026-12-31T12:00:00Z");
-			const oldObj = Status.fromRaw(closureRaw("Dec 31 at 18:00 UTC.", "Dec 31 at 18:00 UTC."), dm, ndm) as Status;
-			const newObj = Status.fromRaw(closureRaw("Dec 31 at 18:00 UTC.", "Dec 31 at 18:00 UTC."), dm, ndm) as Status;
-			// Override timing.end to a date in the next year, bypassing the format's year-defaulting
-			newObj.timing.end = new Date("2027-01-05T18:00:00Z");
-			expect(await Status.updatedPost(oldObj, newObj, now)).toBe(
-				"The airport closure at Test Airport A (#AAA) has been extended by 120 hours to January 5, 2027 at 11:00 AM."
-			);
+			expect(await Status.updatedPost(oldObj, newObj, now as Date | undefined)).toStrictEqual(expected);
 		});
 	});
 });

--- a/src/types/Status.test.ts
+++ b/src/types/Status.test.ts
@@ -948,4 +948,69 @@ describe("Status.updatedPost()", () => {
 			expect(await Status.updatedPost(oldObj, newObj)).toStrictEqual(expected);
 		});
 	});
+
+	// Explicit tests for each date-aware branch in updatedPost().
+	// AAA is in America/Denver: MDT (UTC-6) in spring, MST (UTC-7) in winter.
+	// All tests pass an explicit `now` to avoid coupling to the real system clock.
+	describe("date-aware end time formatting", () => {
+		const dm = new OurAirportsDataManager("Test");
+		const ndm = new NaturalEarthDataManager("Test");
+		const closureRaw = (start: string, reopen: string) => ({
+			"Name": "Airport Closures",
+			"Airport_Closure_List": {
+				"Airport": {
+					"ARPT": "AAA",
+					"Reason": "!AAA 09/001 AAA AD AP CLSD 2109010000-2109012359",
+					"Start": start,
+					"Reopen": reopen
+				}
+			}
+		});
+
+		test("isToday: shows time only (no date)", async () => {
+			// now = April 8, 2026 noon UTC → April 8 6:00 AM MDT (UTC-6)
+			// new Reopen = Apr 08 at 21:00 UTC → April 8 3:00 PM MDT → isToday
+			const now = new Date("2026-04-08T12:00:00Z");
+			const oldObj = Status.fromRaw(closureRaw("Apr 08 at 18:00 UTC.", "Apr 08 at 18:00 UTC."), dm, ndm) as Status;
+			const newObj = Status.fromRaw(closureRaw("Apr 08 at 18:00 UTC.", "Apr 08 at 21:00 UTC."), dm, ndm) as Status;
+			expect(await Status.updatedPost(oldObj, newObj, now)).toBe(
+				"The airport closure at Test Airport A (#AAA) has been extended by 3 hours to 3:00 PM."
+			);
+		});
+
+		test("isSameWeek: shows day name + time", async () => {
+			// now = April 8, 2026 (Wednesday) noon UTC
+			// new Reopen = Apr 10 at 18:00 UTC → April 10 (Friday) noon MDT → same ISO week, not today
+			const now = new Date("2026-04-08T12:00:00Z");
+			const oldObj = Status.fromRaw(closureRaw("Apr 08 at 18:00 UTC.", "Apr 08 at 18:00 UTC."), dm, ndm) as Status;
+			const newObj = Status.fromRaw(closureRaw("Apr 08 at 18:00 UTC.", "Apr 10 at 18:00 UTC."), dm, ndm) as Status;
+			expect(await Status.updatedPost(oldObj, newObj, now)).toBe(
+				"The airport closure at Test Airport A (#AAA) has been extended by 48 hours to Friday at noon."
+			);
+		});
+
+		test("isSameYear: shows month + day + time", async () => {
+			// now = April 8, 2026; new Reopen = Dec 21, 2026 → same year, different week
+			// Dec 21 at 18:00 UTC → Dec 21 11:00 AM MST (UTC-7)
+			const now = new Date("2026-04-08T12:00:00Z");
+			const oldObj = Status.fromRaw(closureRaw("Dec 13 at 18:00 UTC.", "Dec 13 at 18:00 UTC."), dm, ndm) as Status;
+			const newObj = Status.fromRaw(closureRaw("Dec 13 at 18:00 UTC.", "Dec 21 at 18:00 UTC."), dm, ndm) as Status;
+			expect(await Status.updatedPost(oldObj, newObj, now)).toBe(
+				"The airport closure at Test Airport A (#AAA) has been extended by 192 hours to December 21 at 11:00 AM."
+			);
+		});
+
+		test("different year: shows full date with year + time", async () => {
+			// now = Dec 31, 2026; new end = Jan 5, 2027 → different year
+			// Jan 5, 2027 18:00 UTC → Jan 5 11:00 AM MST (UTC-7)
+			const now = new Date("2026-12-31T12:00:00Z");
+			const oldObj = Status.fromRaw(closureRaw("Dec 31 at 18:00 UTC.", "Dec 31 at 18:00 UTC."), dm, ndm) as Status;
+			const newObj = Status.fromRaw(closureRaw("Dec 31 at 18:00 UTC.", "Dec 31 at 18:00 UTC."), dm, ndm) as Status;
+			// Override timing.end to a date in the next year, bypassing the format's year-defaulting
+			newObj.timing.end = new Date("2027-01-05T18:00:00Z");
+			expect(await Status.updatedPost(oldObj, newObj, now)).toBe(
+				"The airport closure at Test Airport A (#AAA) has been extended by 120 hours to January 5, 2027 at 11:00 AM."
+			);
+		});
+	});
 });

--- a/src/types/Status.ts
+++ b/src/types/Status.ts
@@ -531,7 +531,21 @@ export class Status {
 			if (from.timing.end.toISOString() !== to.timing.end.toISOString()) {
 				const extendedByDuration = luxon.DateTime.fromJSDate(to.timing.end).diff(luxon.DateTime.fromJSDate(from.timing.end), "minutes").minutes;
 				const luxonDate = luxon.DateTime.fromJSDate(to.timing.end).setZone(tz ?? "UTC");
-				return `The ${from.type.toString()} at ${await to.airportString()} has been ${extendedByDuration > 0 ? "extended" : "reduced"} by ${minutesToDurationString(Math.abs(extendedByDuration))} to ${luxonDate.toFormat("t")}${!Boolean(tz) ? ` UTC` : ""}.`;
+				const currentLuxonDate = luxon.DateTime.fromJSDate(new Date()).setZone(tz ?? "UTC");
+				const isToday = luxonDate.hasSame(currentLuxonDate, "day");
+				const isSameWeek = luxonDate.hasSame(currentLuxonDate, "week");
+				const isSameYear = luxonDate.hasSame(currentLuxonDate, "year");
+				let newEndString: string;
+				if (isToday) {
+					newEndString = luxonTimeToString(luxonDate);
+				} else if (isSameWeek) {
+					newEndString = `${luxonDate.toFormat("cccc")} at ${luxonTimeToString(luxonDate)}`;
+				} else if (isSameYear) {
+					newEndString = `${luxonDate.toFormat("LLLL d")} at ${luxonTimeToString(luxonDate)}`;
+				} else {
+					newEndString = `${luxonDate.toFormat("LLLL d, yyyy")} at ${luxonTimeToString(luxonDate)}`;
+				}
+				return `The ${from.type.toString()} at ${await to.airportString()} has been ${extendedByDuration > 0 ? "extended" : "reduced"} by ${minutesToDurationString(Math.abs(extendedByDuration))} to ${newEndString}${!Boolean(tz) ? ` UTC` : ""}.`;
 			}
 		}
 		if (from.length.trend !== undefined && to.length.trend !== undefined && from.length.min !== undefined && to.length.min !== undefined && from.length.max !== undefined && to.length.max !== undefined) {

--- a/src/types/Status.ts
+++ b/src/types/Status.ts
@@ -508,7 +508,7 @@ export class Status {
 	/**
 	 * This function is used when a status has been updated to generate a message for a new post.
 	 */
-	static async updatedPost(from: Status, to: Status): Promise<string | undefined> {
+	static async updatedPost(from: Status, to: Status, now: Date = new Date()): Promise<string | undefined> {
 		if (!from.isValid || !to.isValid) {
 			return undefined;
 		}
@@ -531,7 +531,7 @@ export class Status {
 			if (from.timing.end.toISOString() !== to.timing.end.toISOString()) {
 				const extendedByDuration = luxon.DateTime.fromJSDate(to.timing.end).diff(luxon.DateTime.fromJSDate(from.timing.end), "minutes").minutes;
 				const luxonDate = luxon.DateTime.fromJSDate(to.timing.end).setZone(tz ?? "UTC");
-				const currentLuxonDate = luxon.DateTime.fromJSDate(new Date()).setZone(tz ?? "UTC");
+				const currentLuxonDate = luxon.DateTime.fromJSDate(now).setZone(tz ?? "UTC");
 				const isToday = luxonDate.hasSame(currentLuxonDate, "day");
 				const isSameWeek = luxonDate.hasSame(currentLuxonDate, "week");
 				const isSameYear = luxonDate.hasSame(currentLuxonDate, "year");


### PR DESCRIPTION
## Why

When an airport closure is extended across a day boundary, the bot's reply only showed a time — not a date. For example:

> The #airport closure at LaGuardia #Airport (#LGA) has been extended by 208 hours to 6:00 AM.

208 hours is over 8 days later, so users had no way to know *which* day 6:00 AM referred to.

## What changed

`Status.updatedPost()` now uses the same date-aware formatting logic as the initial post when displaying the new end time for a closure extension or reduction:

| Scenario | Example output |
|---|---|
| Same local day as now | `6:00 AM` |
| Same ISO week (but not today) | `Friday at 6:00 AM` |
| Same calendar year (but different week) | `March 31 at 6:00 AM` |
| Different calendar year | `March 31, 2027 at 6:00 AM` |

The previous example would now render as:
> The #airport closure at LaGuardia #Airport (#LGA) has been extended by 208 hours to **April 3 at 6:00 AM**.

A `now: Date = new Date()` parameter was added to `updatedPost()` so tests can pin the reference time without coupling to the real system clock.

## Tests

Three new test cases were added to the existing `tests` array in `Status.updatedPost()` — one for each newly-exercised branch (isToday, isSameWeek, differentYear). The isSameYear branch was already covered by the existing Dec 21 closure extension tests. All cases are expressed as `[oldJSON, newJSON, expected, now?]` tuples to stay consistent with the established array+forEach pattern.