### PR TITLE
Reduce bot memory usage and lazy-load heavy runtime paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,10 @@ COPY . /project
 # Install project dependencies
 RUN npm install
 
+# Keep the long-running bot inside a conservative memory envelope.
+ENV NODE_ENV=production
+ENV NODE_OPTIONS=--max-old-space-size=384
+ENV MALLOC_ARENA_MAX=2
+
 # Set the command to run your app
 CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ Sadly, not all features are available on all platforms. Below is a chart of what
 - A lot of the terminology used in the API is referenced in the [FAA Glossary](https://www.fly.faa.gov/Products/Glossary_of_Terms/glossary_of_terms.html).
 - Data is refreshed every minute from the FAA API. This means that the bot will post a new status within 60 seconds of the FAA reporting a delay.
 
+## Memory Checks
+
+After building the project, run the local memory harnesses with the same 512 MiB target used for the production bot:
+
+```sh
+npm run build
+MEMORY_TARGET_MIB=512 npm run memory:startup
+MEMORY_TARGET_MIB=512 npm run memory:status
+MEMORY_TARGET_MIB=512 npm run memory:image
+```
+
+The image harness performs real map/radar image generation and may need outbound network access for map tiles. On the server, verify the running process with one of these commands:
+
+```sh
+docker stats --no-stream <container-name-or-id>
+ps -o rss= -p <node-pid> | awk '{printf "%.1f MiB\n", $1 / 1024}'
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "build": "tsc",
     "build:watch": "npm run build -- --watch",
     "build:clean": "rimraf dist",
-    "test": "jest"
+    "test": "jest",
+    "memory:startup": "node --expose-gc scripts/memoryHarness.js startup",
+    "memory:status": "node --expose-gc scripts/memoryHarness.js status",
+    "memory:image": "node --expose-gc scripts/memoryHarness.js image"
   },
   "author": "Charlie Fish",
   "license": "MIT",

--- a/scripts/memoryHarness.js
+++ b/scripts/memoryHarness.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+"use strict";
+
+const mode = process.argv[2] ?? "startup";
+const targetMiB = Number(process.env.MEMORY_TARGET_MIB ?? 512);
+
+/**
+ * Run garbage collection when the harness is launched with --expose-gc.
+ */
+function collectGarbage() {
+	if (global.gc) {
+		global.gc();
+	}
+}
+
+/**
+ * Return resident set size in MiB.
+ */
+function rssMiB() {
+	collectGarbage();
+	return process.memoryUsage().rss / 1024 / 1024;
+}
+
+/**
+ * Print and validate the current RSS value.
+ */
+function report(label) {
+	const value = rssMiB();
+	console.log(`${label}: ${value.toFixed(1)} MiB RSS`);
+	if (value > targetMiB) {
+		process.exitCode = 1;
+		console.error(`RSS exceeded ${targetMiB} MiB target.`);
+	}
+}
+
+/**
+ * Use checked-in fixtures instead of the production cache during harness runs.
+ */
+function useFixtureData() {
+	global.jest = {};
+}
+
+/**
+ * Build a delay status that exercises airport lookup and text formatting.
+ */
+function buildFixtureDelayStatus() {
+	const { Status } = require("../dist/types/Status");
+	const { OurAirportsDataManager } = require("../dist/OurAirportsDataManager");
+	const { NaturalEarthDataManager } = require("../dist/NaturalEarthDataManager");
+	const status = Status.fromRaw({
+		"Name": "General Arrival/Departure Delay Info",
+		"Arrival_Departure_Delay_List": {
+			"Delay": {
+				"ARPT": "AAA",
+				"Reason": "WX:Rain",
+				"Arrival_Departure": {
+					"@_Type": "Departure",
+					"Min": "16 minutes",
+					"Max": "30 minutes",
+					"Trend": "Increasing"
+				}
+			}
+		}
+	}, new OurAirportsDataManager("MemoryHarness"), new NaturalEarthDataManager("MemoryHarness"));
+
+	return Array.isArray(status) ? status[0] : status;
+}
+
+async function runStartup() {
+	report("before imports");
+	require("../dist/types/Status");
+	require("../dist/Poster");
+	report("after core imports");
+}
+
+async function runStatus() {
+	useFixtureData();
+	const status = buildFixtureDelayStatus();
+	report("after status construction");
+	await status.toPost();
+	report("after status formatting");
+}
+
+async function runImage() {
+	useFixtureData();
+	const status = buildFixtureDelayStatus();
+	const { NaturalEarthDataManager } = require("../dist/NaturalEarthDataManager");
+	report("before image generation import");
+	const { ImageGenerator } = require("../dist/ImageGenerator");
+	report("after image generation import");
+	const image = await new ImageGenerator(status, new NaturalEarthDataManager("MemoryHarness")).generate();
+	console.log(`generated image bytes: ${image?.content.length ?? 0}`);
+	report("after image generation");
+}
+
+(async () => {
+	switch (mode) {
+		case "startup":
+			await runStartup();
+			break;
+		case "status":
+			await runStatus();
+			break;
+		case "image":
+			await runImage();
+			break;
+		default:
+			console.error(`Unknown memory harness mode: ${mode}`);
+			process.exitCode = 1;
+	}
+})();

--- a/src/ImageGenerator.ts
+++ b/src/ImageGenerator.ts
@@ -1,13 +1,11 @@
 import { mapToImage } from "maptoimage";
-import { Status } from "./types/Status";
+import type { Status } from "./types/Status";
 import Jimp from "jimp";
-import GeoJSONToTileImages from "geojson-to-tile-images";
-import * as turf from "@turf/turf";
-import getClosestLandmarkToPoint from "./utils/getClosestLandmarkToPoint";
-import { NaturalEarthDataManager } from "./NaturalEarthDataManager";
+import type { NaturalEarthDataManager } from "./NaturalEarthDataManager";
 import generateAltTextForWeatherRadarImage from "./utils/generateAltTextForWeatherRadarImage";
 import * as fs from "fs";
 import * as path from "path";
+import { ImageType } from "./ImageType";
 
 const SIZE = {
 	"width": 1280,
@@ -45,11 +43,6 @@ function getZoomLevel(bbox: any, mapWidth: number, mapHeight: number): number {
 	return adjustedZoomLevel;
 }
 
-
-export enum ImageType {
-	"radar",
-	"geojson"
-}
 
 interface ImageOutput {
 	"content": Buffer;
@@ -125,6 +118,7 @@ export class ImageGenerator {
 			attribution += "\nRadar data from Iowa Environmental Mesonet.";
 		}
 		if (this.types.includes(ImageType.geojson) && this.#status.geoJSON !== undefined) {
+			const { default: GeoJSONToTileImages } = await import("geojson-to-tile-images");
 			const geojson = this.#status.geoJSON;
 			layers.push(async (z: number, x: number, y: number): Promise<Buffer> => {
 				return await GeoJSONToTileImages({
@@ -156,6 +150,8 @@ export class ImageGenerator {
 					"lng": airport.longitude_deg
 				};
 			} else if (this.#status.geoJSON) {
+				const turf = await import("@turf/turf");
+				const { default: getClosestLandmarkToPoint } = await import("./utils/getClosestLandmarkToPoint");
 				const centerPoint = turf.center(this.#status.geoJSON);
 				const states = await this.#naturalEarthDataManager.geoJSON("ne_110m_admin_1_states_provinces");
 				const statesCenterPoints = states ? turf.featureCollection(states.features.map((feature) => {
@@ -179,6 +175,8 @@ export class ImageGenerator {
 		})();
 		const zoom: number = await (async () => {
 			if (this.types.includes(ImageType.geojson) && this.#status.geoJSON) {
+				const turf = await import("@turf/turf");
+				const { default: getClosestLandmarkToPoint } = await import("./utils/getClosestLandmarkToPoint");
 				const us = (await this.#naturalEarthDataManager.geoJSON("ne_110m_admin_0_countries"))?.features.find((feature) => feature.properties?.NAME === "United States of America");
 				if (us === undefined) {
 					throw new Error("United States not found in Natural Earth data.");

--- a/src/ImageType.test.ts
+++ b/src/ImageType.test.ts
@@ -1,0 +1,34 @@
+test("image type detection does not load ImageGenerator", () => {
+	jest.resetModules();
+
+	const imageGeneratorPath = require.resolve("./ImageGenerator");
+	const { ImageType } = require("./ImageType");
+	const { Reason } = require("./types/Reason");
+	const { Status } = require("./types/Status");
+
+	const airspaceFlow = Status.fromRaw({
+		"Name": "Airspace Flow Programs",
+		"Airspace_Flow_List": {
+			"Airspace_Flow": {
+				"CTL_Element": "TEST",
+				"Reason": "VOL:Volume",
+				"Line": {
+					"Point": [
+						{
+							"@_Lat": "40",
+							"@_Long": "-105"
+						},
+						{
+							"@_Lat": "41",
+							"@_Long": "-104"
+						}
+					]
+				}
+			}
+		}
+	}, undefined, undefined);
+
+	expect(new Reason("WX:Rain").imageType()).toStrictEqual([ImageType.radar]);
+	expect(airspaceFlow.imageType()).toStrictEqual([ImageType.geojson]);
+	expect(require.cache[imageGeneratorPath]).toBeUndefined();
+});

--- a/src/ImageType.ts
+++ b/src/ImageType.ts
@@ -1,0 +1,7 @@
+/**
+ * Image variants that can be attached to social posts.
+ */
+export enum ImageType {
+	"radar",
+	"geojson"
+}

--- a/src/NaturalEarthDataManager.test.ts
+++ b/src/NaturalEarthDataManager.test.ts
@@ -1,0 +1,40 @@
+import * as path from "path";
+import { NaturalEarthDataManager } from "./NaturalEarthDataManager";
+
+const fs = require("fs") as typeof import("fs");
+const statesGeoJSONPath = path.join("naturalearth", "ne_110m_admin_1_states_provinces.geojson");
+
+function countStateGeoJSONReads(readSpy: jest.SpyInstance): number {
+	return readSpy.mock.calls.filter((call) => String(call[0]).endsWith(statesGeoJSONPath)).length;
+}
+
+test("geoJSON() reuses parsed Natural Earth data", async () => {
+	const manager = new NaturalEarthDataManager("Test");
+	const readSpy = jest.spyOn(fs, "readFileSync");
+
+	try {
+		const first = await manager.geoJSON("ne_110m_admin_1_states_provinces");
+		const second = await manager.geoJSON("ne_110m_admin_1_states_provinces");
+
+		expect(second).toBe(first);
+		expect(countStateGeoJSONReads(readSpy)).toBe(1);
+	} finally {
+		readSpy.mockRestore();
+	}
+});
+
+test("clearGeoJSONCache() drops parsed Natural Earth data", async () => {
+	const manager = new NaturalEarthDataManager("Test");
+	const readSpy = jest.spyOn(fs, "readFileSync");
+
+	try {
+		const first = await manager.geoJSON("ne_110m_admin_1_states_provinces");
+		manager.clearGeoJSONCache();
+		const second = await manager.geoJSON("ne_110m_admin_1_states_provinces");
+
+		expect(second).not.toBe(first);
+		expect(countStateGeoJSONReads(readSpy)).toBe(2);
+	} finally {
+		readSpy.mockRestore();
+	}
+});

--- a/src/NaturalEarthDataManager.ts
+++ b/src/NaturalEarthDataManager.ts
@@ -1,8 +1,5 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as crypto from "crypto";
-import { GeneralObject } from "js-object-utilities";
-import { Airport } from "./types/Airport";
 const fetch = require("node-fetch");
 const unzipper = require("unzipper");
 const { exec } = require("child_process");
@@ -32,6 +29,7 @@ const items = [
 
 export class NaturalEarthDataManager {
 	#lastUpdatedDate: number | undefined;
+	#geoJSONCache = new Map<string, GeoJSON.FeatureCollection>();
 	userAgent: string;
 
 	constructor(userAgent: string) {
@@ -46,6 +44,13 @@ export class NaturalEarthDataManager {
 		return items.every((item) => fs.existsSync(path.join(dataPath(), `${item.name}.geojson`)));
 	}
 
+	/**
+	 * Clears parsed GeoJSON objects after the on-disk cache changes.
+	 */
+	clearGeoJSONCache() {
+		this.#geoJSONCache.clear();
+	}
+
 	async updateCache(force: boolean = false) {
 		const oneDayInMS = 24 * 60 * 60 * 1000; // 1 day in milliseconds
 		const shouldRun = force || !this.#cacheExists || !this.#lastUpdatedDate || this.#lastUpdatedDate < Date.now() - oneDayInMS;
@@ -54,6 +59,7 @@ export class NaturalEarthDataManager {
 		} else {
 			try {
 				console.log("Updating NaturalEarth cache");
+				this.clearGeoJSONCache();
 
 				await fs.promises.mkdir(dataPath(), {
 					"recursive": true
@@ -105,6 +111,7 @@ export class NaturalEarthDataManager {
 
 				this.#lastUpdatedDate = Date.now();
 				await fs.promises.writeFile(path.join(dataPath(), "..", "lastUpdatedDate.txt"), this.#lastUpdatedDate.toString());
+				this.clearGeoJSONCache();
 				console.log("NaturalEarth Cache updated");
 			} catch (e) {
 				console.error("Failed to update NaturalEarth cache");
@@ -118,11 +125,17 @@ export class NaturalEarthDataManager {
 		if (!item) {
 			return undefined;
 		} else {
+			if (this.#geoJSONCache.has(type)) {
+				return this.#geoJSONCache.get(type);
+			}
+
 			const geoJSONPath = path.join(dataPath(), `${item.name}.geojson`);
 			if (!fs.existsSync(geoJSONPath)) {
 				await this.updateCache();
 			}
-			return JSON.parse(fs.readFileSync(geoJSONPath, "utf8"));
+			const geoJSON = JSON.parse(fs.readFileSync(geoJSONPath, "utf8"));
+			this.#geoJSONCache.set(type, geoJSON);
+			return geoJSON;
 		}
 	}
 }

--- a/src/Poster.ts
+++ b/src/Poster.ts
@@ -1,20 +1,14 @@
 import "websocket-polyfill";
 
-import { Config, ContentTypeEnum, SocialNetwork, SocialNetworkType, defaultIncludeHashtags } from "./types/Config";
-import { S3 } from "@aws-sdk/client-s3";
-import { BskyAgent, RichText, AppBskyFeedPost, BlobRef } from "@atproto/api";
+import { Config, SocialNetwork, SocialNetworkType, defaultIncludeHashtags } from "./types/Config";
 import { GeneralObject } from "js-object-utilities";
 import * as nostrtools from "nostr-tools";
 import { parseHashtags } from "./utils/parseHashtags";
-import { createRestAPIClient as Masto, createStreamingAPIClient as MastoStream } from "masto";
-import * as htmlToText from "html-to-text";
-import { resizeImage } from "./utils/resizeImage";
 import * as fs from "fs";
 import * as path from "path";
-import { randomUUID, UUID, createHash } from "crypto";
-import Jimp from "jimp";
-import * as blurhash from "blurhash";
-import PosterV2, { PostContent } from "./PosterV2";
+import type { PostContent } from "./PosterV2";
+
+type PosterV2Instance = import("./PosterV2").default;
 
 const hashtagWords = [
 	"weather",
@@ -36,10 +30,20 @@ interface Post {
 export class Poster {
 	#config: Config;
 
-	#posterV2: PosterV2 = new PosterV2();
+	#posterV2: Promise<PosterV2Instance> | undefined;
 
 	constructor(config: Config) {
 		this.#config = config;
+	}
+
+	/**
+	 * Lazily load the heavier social posting package only when posting is required.
+	 */
+	async #getPosterV2(): Promise<PosterV2Instance> {
+		if (!this.#posterV2) {
+			this.#posterV2 = import("./PosterV2").then(({ default: PosterV2 }) => new PosterV2());
+		}
+		return this.#posterV2;
 	}
 
 	/**
@@ -51,6 +55,7 @@ export class Poster {
 	 */
 	async post(content: PostContent, rawXML: string, contentTypes: string[]): Promise<{ [key: string]: any }> {
 		let returnObject: { [key: string]: any } = {};
+		const posterV2 = await this.#getPosterV2();
 
 		await Promise.all(this.#config.socialNetworks.map(async (socialNetwork) => {
 			if (!contentTypes.includes(socialNetwork.contentType)) {
@@ -65,7 +70,7 @@ export class Poster {
 			}
 
 			try {
-				returnObject[socialNetwork.uuid] = await this.#posterV2.post(socialNetwork, {
+				returnObject[socialNetwork.uuid] = await posterV2.post(socialNetwork, {
 					"message": socialMessage,
 					"image": content.image
 				});
@@ -86,11 +91,13 @@ export class Poster {
 
 		console.log(`Reposting to ${socialNetwork.uuid}`, post);
 
-		return this.#posterV2.repost(socialNetwork, post);
+		const posterV2 = await this.#getPosterV2();
+		return posterV2.repost(socialNetwork, post);
 	}
 
 	async reply(socialNetworkUUID: string, replyTo: GeneralObject<any>, content: PostContent, rawXML: string): Promise<{ [key: string]: any }> {
 		let returnObject: { [key: string]: any } = {};
+		const posterV2 = await this.#getPosterV2();
 
 		const socialNetwork = this.#config.socialNetworks.find((v) => v.uuid === socialNetworkUUID);
 		if (!socialNetwork) {
@@ -110,7 +117,7 @@ export class Poster {
 		}
 
 		try {
-			returnObject[socialNetwork.uuid] = await this.#posterV2.reply(socialNetwork, replyTo, {
+			returnObject[socialNetwork.uuid] = await posterV2.reply(socialNetwork, replyTo, {
 				"message": socialMessage,
 				"image": content.image
 			});
@@ -136,7 +143,8 @@ export class Poster {
 
 		try {
 			switch (socialNetwork.type) {
-				case SocialNetworkType.mastodon:
+				case SocialNetworkType.mastodon: {
+					const { createRestAPIClient: Masto } = await import("masto");
 					const masto = Masto({
 						"url": `${socialNetwork.credentials.endpoint}`,
 						"accessToken": socialNetwork.credentials.password
@@ -168,6 +176,7 @@ export class Poster {
 						throw e;
 					}
 					break;
+				}
 				case SocialNetworkType.bluesky:
 					break;
 				case SocialNetworkType.s3:
@@ -365,7 +374,9 @@ export class Listener {
 			}
 
 			switch (socialNetwork.type) {
-				case SocialNetworkType.mastodon:
+				case SocialNetworkType.mastodon: {
+					const { createStreamingAPIClient: MastoStream } = await import("masto");
+					const htmlToText = await import("html-to-text");
 					const masto = MastoStream({
 						"accessToken": socialNetwork.credentials.password,
 						"streamingApiUrl": `${(socialNetwork.credentials.streamingEndpoint ?? socialNetwork.credentials.endpoint).replace("https://", "wss://")}/api/v1/streaming`
@@ -407,7 +418,8 @@ export class Listener {
 							console.log("No item or error in Mastodon listener.")
 						}
 					});
-				break;
+					break;
+				}
 				case SocialNetworkType.s3:
 					break;
 				case SocialNetworkType.bluesky:

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ import * as objectUtils from "js-object-utilities";
 import * as rimraf from "rimraf";
 import { OurAirportsDataManager } from "./OurAirportsDataManager";
 import { NaturalEarthDataManager } from "./NaturalEarthDataManager";
-import { ImageGenerator } from "./ImageGenerator";
 import express from "express";
 import { minutesToDurationString } from "./utils/minutesToDurationString";
 import { fetchWithRetry } from "./utils/fetchWithRetry";
@@ -70,7 +69,17 @@ if (config.webServer) {
 						res.setHeader("Content-Length", data.ContentLength);
 					}
 
-					res.send(Buffer.from(await data.Body.transformToByteArray()));
+					const body = data.Body as NodeJS.ReadableStream & { transformToByteArray?: () => Promise<Uint8Array> };
+					if (typeof body.pipe === "function") {
+						// Stream S3 images to avoid buffering large assets in process memory.
+						body.on("error", next);
+						body.pipe(res);
+					} else if (typeof body.transformToByteArray === "function") {
+						res.send(Buffer.from(await body.transformToByteArray()));
+					} else {
+						console.warn(`Unsupported S3 object body for image: ${key}`);
+						next();
+					}
 				} else {
 					console.warn(`No body for S3 object: ${key}`, data);
 					next();
@@ -103,6 +112,22 @@ const naturalEarthDataManager = new NaturalEarthDataManager(USER_AGENT);
 const poster = new Poster(config);
 
 let currentDelays: Status[] | null = null;
+
+/**
+ * Generate an image only when a status advertises an image type.
+ */
+async function generateImageForDelay(delay: Status) {
+	const imageTypes = [
+		...delay.reason.imageType(),
+		...delay.imageType()
+	];
+	if (imageTypes.length === 0) {
+		return undefined;
+	}
+
+	const { ImageGenerator } = await import("./ImageGenerator");
+	return new ImageGenerator(delay, naturalEarthDataManager).generate();
+}
 
 async function run (firstRun: boolean) {
 	console.log(`Start run: ${Date.now()}`);
@@ -310,7 +335,7 @@ async function run (firstRun: boolean) {
 			const post = await delay.toPost();
 			let image;
 			try {
-				image = await new ImageGenerator(delay, naturalEarthDataManager).generate();
+				image = await generateImageForDelay(delay);
 			} catch (e) {
 				console.error("Failed to generate image:");
 				console.error(e);

--- a/src/types/Reason.ts
+++ b/src/types/Reason.ts
@@ -1,4 +1,4 @@
-import { ImageType } from "../ImageGenerator";
+import { ImageType } from "../ImageType";
 
 enum ParentType {
 	WEATHER = "WX",

--- a/src/types/Status.ts
+++ b/src/types/Status.ts
@@ -7,7 +7,7 @@ import { parseDurationString } from "../utils/parseDurationString";
 import { minutesToDurationString } from "../utils/minutesToDurationString";
 import { OurAirportsDataManager } from "../OurAirportsDataManager";
 import { NaturalEarthDataManager } from "../NaturalEarthDataManager";
-import { ImageType } from "../ImageGenerator";
+import { ImageType } from "../ImageType";
 import formatNumber from "../utils/formatNumber";
 import * as turf from "@turf/turf";
 import bearingToString from "../utils/bearingToString";

--- a/src/utils/generateAltTextForWeatherRadarImage.test.ts
+++ b/src/utils/generateAltTextForWeatherRadarImage.test.ts
@@ -1,0 +1,17 @@
+import Jimp from "jimp";
+import generateAltTextForWeatherRadarImage from "./generateAltTextForWeatherRadarImage";
+
+test("generateAltTextForWeatherRadarImage() reports no storms for transparent radar", async () => {
+	const image = await new Jimp(3, 3, 0x00000000);
+	const buffer = await image.getBufferAsync(Jimp.MIME_PNG);
+
+	expect(await generateAltTextForWeatherRadarImage(buffer)).toStrictEqual("The map shows no storms based on weather radar.");
+});
+
+test("generateAltTextForWeatherRadarImage() scans radar pixels without per-pixel arrays", async () => {
+	const image = await new Jimp(3, 3, 0x00000000);
+	image.setPixelColor(Jimp.rgbaToInt(170, 0, 0, 255), 2, 2);
+	const buffer = await image.getBufferAsync(Jimp.MIME_PNG);
+
+	expect(await generateAltTextForWeatherRadarImage(buffer)).toStrictEqual("The map has a weather radar layer showing heavy precipitation to the east.");
+});

--- a/src/utils/generateAltTextForWeatherRadarImage.ts
+++ b/src/utils/generateAltTextForWeatherRadarImage.ts
@@ -3,75 +3,51 @@ import * as fs from "fs";
 import path from "path";
 import bearingToString from "./bearingToString";
 
+const NO_REFLECTIVITY = -1;
+let radarColorIndexCache: Map<string, number> | undefined;
+
 export default async function (buffer: Buffer): Promise<string> {
 	const jimpImg = await Jimp.read(buffer);
 	const width = jimpImg.getWidth();
 	const height = jimpImg.getHeight();
 
-	const radarColorIndex = convertCSVToJSONWithHeaders(fs.readFileSync(path.join(__dirname, "..", "..", "radarColorIndex.csv"), "utf-8"));
-
+	const radarColorIndex = getRadarColorIndex();
 	const scanIterator = jimpImg.scanIterator(0, 0, jimpImg.getWidth(), jimpImg.getHeight());
-	let radarDbzPerPixel = [];
+	const center = { x: width / 2, y: height / 2 };
+	const res: {[key: string]: {[key: number]: number}} = {};
+
 	for (const { idx, x, y } of scanIterator) {
 		const r = jimpImg.bitmap.data[idx + 0];
 		const g = jimpImg.bitmap.data[idx + 1];
 		const b = jimpImg.bitmap.data[idx + 2];
 		const a = jimpImg.bitmap.data[idx + 3];
-
-		if (a === 0) {
-			radarDbzPerPixel.push(null);
-		} else {
-			const colorIndex = radarColorIndex.find((obj, i) => {
-				return obj.Red === r && obj.Green === g && obj.Blue === b;
-			});
-			if (!colorIndex) {
-				throw new Error(`No color index found for color ${r}, ${g}, ${b}, ${idx}, ${x}, ${y}`);
-			}
-			radarDbzPerPixel.push(colorIndex["Value (dBZ)"]);
-		}
-	}
-
-	const reflectivityPerPixel = radarDbzPerPixel.map((dbz) => {
-		if (dbz === null) {
-			return null;
-		} else if (dbz < 0) {
-			return ReflectivityIntensity.extremelyLight;
-		} else if (dbz < 20) {
-			return ReflectivityIntensity.veryLight;
-		} else if (dbz < 40) {
-			return ReflectivityIntensity.light;
-		} else if (dbz < 50) {
-			return ReflectivityIntensity.moderate;
-		} else if (dbz < 65) {
-			return ReflectivityIntensity.heavy;
-		} else {
-			return ReflectivityIntensity.extremelyHeavy;
-		}
-	});
-
-	const center = { x: width / 2, y: height / 2 };
-	const res = reflectivityPerPixel.reduce((previousValue: any, reflectivity, i) => {
-		const x = i % width;
-		const y = Math.floor(i / width);
 		const bearing = Math.atan2(y - center.y, x - center.x) * 180 / Math.PI;
-
 		const bearingStr = bearingToString(bearing, true);
 		if (!bearingStr) {
-			return previousValue;
+			continue;
 		}
 
-		if (!previousValue[bearingStr]) {
-			previousValue[bearingStr] = {
-				[reflectivity ?? -1]: 1
-			};
-		} else if (previousValue[bearingStr] && !previousValue[bearingStr][reflectivity ?? -1]) {
-			previousValue[bearingStr][reflectivity ?? -1] = 1;
+		let reflectivity: ReflectivityIntensity | typeof NO_REFLECTIVITY;
+		if (a === 0) {
+			reflectivity = NO_REFLECTIVITY;
 		} else {
-			previousValue[bearingStr][reflectivity ?? -1]++;
+			const dbz = radarColorIndex.get(`${r},${g},${b}`);
+			if (dbz === undefined) {
+				throw new Error(`No color index found for color ${r}, ${g}, ${b}, ${idx}, ${x}, ${y}`);
+			}
+			reflectivity = reflectivityIntensityForDbz(dbz);
 		}
 
-		return previousValue;
-	}, {});
+		if (!res[bearingStr]) {
+			res[bearingStr] = {
+				[reflectivity]: 1
+			};
+		} else if (!res[bearingStr][reflectivity]) {
+			res[bearingStr][reflectivity] = 1;
+		} else {
+			res[bearingStr][reflectivity]++;
+		}
+	}
 
 	const data = Object.entries(res).reduce((previousValue: any, currentValue: any) => {
 		const noReflectivity = currentValue[1]["-1"] ?? 0;
@@ -127,6 +103,17 @@ function convertCSVToJSONWithHeaders(string: string): {[key: string]: any}[] {
 	});
 }
 
+/**
+ * Build a reusable lookup table for radar RGB values.
+ */
+function getRadarColorIndex(): Map<string, number> {
+	if (!radarColorIndexCache) {
+		const radarColorIndex = convertCSVToJSONWithHeaders(fs.readFileSync(path.join(__dirname, "..", "..", "radarColorIndex.csv"), "utf-8"));
+		radarColorIndexCache = new Map(radarColorIndex.map((obj) => [`${obj.Red},${obj.Green},${obj.Blue}`, obj["Value (dBZ)"]]));
+	}
+	return radarColorIndexCache;
+}
+
 // https://www.noaa.gov/jetstream/reflectivity
 enum ReflectivityIntensity {
 	extremelyLight, // -35 to 0 dBZ
@@ -137,8 +124,28 @@ enum ReflectivityIntensity {
 	extremelyHeavy, // >65 dBZ
 }
 
-function reflectivityIntensityToString(intensity: ReflectivityIntensity): string {
-	switch (intensity) {
+/**
+ * Convert a radar dBZ value into a coarse intensity bucket.
+ */
+function reflectivityIntensityForDbz(dbz: number): ReflectivityIntensity {
+	if (dbz < 0) {
+		return ReflectivityIntensity.extremelyLight;
+	} else if (dbz < 20) {
+		return ReflectivityIntensity.veryLight;
+	} else if (dbz < 40) {
+		return ReflectivityIntensity.light;
+	} else if (dbz < 50) {
+		return ReflectivityIntensity.moderate;
+	} else if (dbz < 65) {
+		return ReflectivityIntensity.heavy;
+	} else {
+		return ReflectivityIntensity.extremelyHeavy;
+	}
+}
+
+function reflectivityIntensityToString(intensity: ReflectivityIntensity | string): string {
+	const normalizedIntensity = typeof intensity === "string" ? parseInt(intensity) : intensity;
+	switch (normalizedIntensity) {
 		case ReflectivityIntensity.extremelyLight:
 			return "extremely light";
 		case ReflectivityIntensity.veryLight:
@@ -152,4 +159,5 @@ function reflectivityIntensityToString(intensity: ReflectivityIntensity): string
 		case ReflectivityIntensity.extremelyHeavy:
 			return "heavy";
 	}
+	return "unknown";
 }


### PR DESCRIPTION
## Summary
- Lower the Docker/runtime memory envelope with production defaults and a capped Node heap.
- Defer loading of image, posting, and streaming dependencies until they are actually needed.
- Cache parsed Natural Earth GeoJSON in memory and clear it when the on-disk cache refreshes.
- Stream S3 image responses instead of buffering them in full.
- Add memory harness scripts, README guidance, and regression tests for lazy loading and GeoJSON caching.

## Testing
- Not run (not requested)
- Added unit coverage for image type detection, Natural Earth GeoJSON caching, and radar alt-text generation